### PR TITLE
Top Issues Dashboard

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,3 @@
+
+---
+Please upvote :+1: this issue if you are interested in it.

--- a/.github/workflows/top-issues-dashboard.yml
+++ b/.github/workflows/top-issues-dashboard.yml
@@ -21,4 +21,3 @@ jobs:
           top_bugs: false
           top_features: false
           top_pull_requests: false
-          

--- a/.github/workflows/top-issues-dashboard.yml
+++ b/.github/workflows/top-issues-dashboard.yml
@@ -18,6 +18,6 @@ jobs:
           dashboard: true
           dashboard_show_total_reactions: true
           top_issues: true
-          top_bugs: true
-          top_features: true
-          top_pull_requests: true
+          top_bugs: false
+          top_features: false
+          top_pull_requests: false

--- a/.github/workflows/top-issues-dashboard.yml
+++ b/.github/workflows/top-issues-dashboard.yml
@@ -1,0 +1,23 @@
+name: Top issues action.
+on: [push]
+#on:
+#  schedule:
+#    - cron: '0 0 */1 * *'
+
+jobs:
+  ShowAndLabelTopIssues:
+    name: Display and label top issues.
+    runs-on: ubuntu-latest
+    steps:
+      - name: Run top issues action
+        uses: rickstaa/top-issues-action@v1
+        env:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          label: false
+          dashboard: true
+          dashboard_show_total_reactions: true
+          top_issues: true
+          top_bugs: true
+          top_features: true
+          top_pull_requests: true

--- a/.github/workflows/top-issues-dashboard.yml
+++ b/.github/workflows/top-issues-dashboard.yml
@@ -1,8 +1,8 @@
 name: Top issues action.
-on: [push]
-#on:
-#  schedule:
-#    - cron: '0 0 */1 * *'
+#on: [push]
+on:
+  schedule:
+    - cron: '0 0 */1 * *'
 
 jobs:
   ShowAndLabelTopIssues:
@@ -14,6 +14,7 @@ jobs:
         env:
           github_token: ${{ secrets.GITHUB_TOKEN }}
         with:
+          top_list_size: 5
           label: true
           dashboard: true
           dashboard_show_total_reactions: true

--- a/.github/workflows/top-issues-dashboard.yml
+++ b/.github/workflows/top-issues-dashboard.yml
@@ -21,3 +21,4 @@ jobs:
           top_bugs: false
           top_features: false
           top_pull_requests: false
+          

--- a/.github/workflows/top-issues-dashboard.yml
+++ b/.github/workflows/top-issues-dashboard.yml
@@ -14,7 +14,7 @@ jobs:
         env:
           github_token: ${{ secrets.GITHUB_TOKEN }}
         with:
-          label: false
+          label: true
           dashboard: true
           dashboard_show_total_reactions: true
           top_issues: true

--- a/README.md
+++ b/README.md
@@ -13,6 +13,9 @@ I will lean heavily on OSDev Wiki ([C Sharp Bare Bones](https://wiki.osdev.org/C
 The obligatory screenshot, which (at the moment), is pretty underwhelming I admit:
 ![PatienceOS - boot splash](https://github.com/FrankRay78/PatienceOS/assets/52075808/4ffa65a2-9818-4502-a2cf-ceee99b70e93)
 
+> [!IMPORTANT]\
+> Please upvote :+1: the [issues](https://github.com/FrankRay78/PatienceOS/issues) you are most interested in, the [Top Issues Dashboard](https://github.com/FrankRay78/PatienceOS/issues/5) tracks community interest. 
+
 ## Playing with PatienceOS
 
 ### Windows 10 Host

--- a/README.md
+++ b/README.md
@@ -73,7 +73,13 @@ File | Type | Purpose |
 `src\PatienceOS.NoStdLib.sln` | Visual Studio 2022 solution; only contains the PatienceOS project | Builds and links the kernel against the custom .Net runtime, `zerosharp.cs`. Handy for when you are coding PatienceOS within Visual Studio and want to quickly check building against the custom runtime types.
 `src\PatienceOS.sln` | Visual Studio 2022 solution; contains the PatienceOS project and accompanying unit test project | Builds and links the kernel against the standard .Net 8.0 runtime. Allows you to run the PatienceOS unit tests within the built-in Visual Studio Test Explorer, as per any other unit test project. 
 
-I'm not currently accepting pull requests as this is a personal learning project. However, please feel free to raise issues if you want to discuss a particular matter with your fellow GitHub users and/or fork the repository for your own purposes.
+## Contributing
+> [!IMPORTANT]\
+> I'm not currently accepting pull requests as this is a personal learning project. 
+
+Please upvote :+1: any existing [issues](https://github.com/FrankRay78/PatienceOS/issues) you are interested in being worked on. You can also contribute to discussions with your fellow GitHub users and me by commenting on existing issues, and by raising new issues you want to be considered for development.
+
+All reasonable interactions are welcomed but please **don't be offended** if I close or delete issues or comments etc, as I see fit, as this is my personal learning project. You are welcome to fork the repository for your own purposes. 
 
 ## Build toolchain
 


### PR DESCRIPTION
This PR relates to issue https://github.com/FrankRay78/PatienceOS/issues/12 and includes the following changes:

1. Use the [Top Issues GitHub Action](https://github.com/marketplace/actions/top-issues-action) to re-generate the 'Top Issues Dashboard' on a nightly basis

2. Create a new issue template that includes a CTA for issue voting (useful for when someone lands directly on an open issue from a Google search)

3. Reference the [Top Issues Dashboard](https://github.com/FrankRay78/PatienceOS/issues/5) in the project's README.md and mention the ability to vote