### PR TITLE
Enable cpu support for sse in bootstrap

### DIFF
--- a/build/build.cmd
+++ b/build/build.cmd
@@ -14,7 +14,7 @@ mkdir ..\bin
 cd ..\bin
 
 csc /debug:embedded /noconfig /nostdlib /runtimemetadataversion:v4.0.30319 ../src/PatienceOS.Kernel/kernel.cs ../src/PatienceOS.Kernel/Console.cs ../src/PatienceOS.Kernel/FrameBuffer.cs ../src/PatienceOS.Kernel/zerosharp.cs /out:kernel.ilexe /langversion:latest /unsafe || goto Error
-ilc --targetos windows --targetarch x86 kernel.ilexe -g -o kernel.obj --systemmodule kernel --map kernel.map -O || goto Error
+ilc --targetos windows --targetarch x86 --instruction-set base --verbose kernel.ilexe -g -o kernel.obj --systemmodule kernel --map kernel.map -O || goto Error
 nasm -f win32 -o loader.obj ../src/loader.asm || goto Error
 
 :: QEMU doesn't boot properly when I use the Microsoft linker, continually stuck in a BIOS loop looking for something to boot.
@@ -23,7 +23,7 @@ nasm -f win32 -o loader.obj ../src/loader.asm || goto Error
 
 ld -m i386pe -T ../src/linker.ld -o kernel.bin loader.obj kernel.obj || goto Error
 objcopy -O elf32-i386 kernel.bin kernel.elf || goto Error
-qemu-system-i386 -kernel kernel.elf || goto Error
+qemu-system-i386 -kernel kernel.elf -d int -no-reboot -no-shutdown || goto Error
 
 cd ..\build
 exit /B

--- a/build/build.cmd
+++ b/build/build.cmd
@@ -23,7 +23,7 @@ nasm -f win32 -o loader.obj ../src/loader.asm || goto Error
 
 ld -m i386pe -T ../src/linker.ld -o kernel.bin loader.obj kernel.obj || goto Error
 objcopy -O elf32-i386 kernel.bin kernel.elf || goto Error
-qemu-system-i386 -kernel kernel.elf -d int -no-reboot -no-shutdown || goto Error
+qemu-system-i386 -cpu pentium3 -kernel kernel.elf -d int -no-reboot -no-shutdown || goto Error
 
 cd ..\build
 exit /B

--- a/src/PatienceOS.Kernel/Console.cs
+++ b/src/PatienceOS.Kernel/Console.cs
@@ -30,6 +30,8 @@
             }
         }
 
+        private byte foregroundColor = 0x0F;
+
         /// <summary>
         /// Print a string to the current cursor position
         /// </summary>

--- a/src/PatienceOS.Kernel/Console.cs
+++ b/src/PatienceOS.Kernel/Console.cs
@@ -11,6 +11,7 @@
         private FrameBuffer frameBuffer;
 
         private int pos = 0;
+        private byte foregroundColor = 0x0F; // White
 
         public Console(int width, int height, FrameBuffer frameBuffer)
         {
@@ -30,8 +31,6 @@
             }
         }
 
-        private byte foregroundColor = 0x0F;
-
         /// <summary>
         /// Print a string to the current cursor position
         /// </summary>
@@ -42,7 +41,7 @@
                 for (int i = 0; i < s.Length; i++)
                 {
                     frameBuffer.Write(pos, (byte)ps[i]);
-                    frameBuffer.Write(pos + 1, 0x0F);
+                    frameBuffer.Write(pos + 1, foregroundColor);
 
                     pos += 2;
                 }


### PR DESCRIPTION
Implements the fix suggested here: [Including an unused variable corrupts the multiboot kernel](https://forum.osdev.org/viewtopic.php?f=1&t=57204&start=0)

Unblocks proceeding with development here: https://github.com/FrankRay78/PatienceOS/issues/16